### PR TITLE
Fix problems on some elements

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -98,12 +98,11 @@ function updateIconForTab(tab) {
     let hasAnyNonPausedMediaElements = false;
     let hasAnyNonMutedMediaElements = false;
     for (mediaElement of mediaElements) {
-        if (mediaElement.mozHasAudio) {
-            if (!mediaElement.paused) {
-                hasAnyNonPausedMediaElements = true;
-                if (!mediaElement.muted) {
-                    hasAnyNonMutedMediaElements = true;
-                }
+        if (!mediaElement.paused) {
+            hasAnyNonPausedMediaElements = true;
+            if (!mediaElement.muted) {
+                hasAnyNonMutedMediaElements = true;
+                break;
             }
         }
     }


### PR DESCRIPTION
Perhaps you missed my comment on the commit that added mozHasAudio, but it seems to break things, as reported on the Pale Moon forums as well.

This will remove the check so it works properly on all elements again. Also, once we have hasAnyNonMutedMediaElements set to true, don't need to keep checking so break.