### PR TITLE
Re-add mozHasAudio

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -98,11 +98,13 @@ function updateIconForTab(tab) {
     let hasAnyNonPausedMediaElements = false;
     let hasAnyNonMutedMediaElements = false;
     for (mediaElement of mediaElements) {
-        if (!mediaElement.paused) {
-            hasAnyNonPausedMediaElements = true;
-            if (!mediaElement.muted) {
-                hasAnyNonMutedMediaElements = true;
-                break;
+        if (mediaElement.mozHasAudio !== false) {
+            if (!mediaElement.paused) {
+                hasAnyNonPausedMediaElements = true;
+                if (!mediaElement.muted) {
+                    hasAnyNonMutedMediaElements = true;
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
It broke audio elements before because they return undefined. Adding it back like this seems to work just fine.