### PR TITLE
Allow for easier introduction of future media element types

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -261,7 +261,7 @@ function enableMediaNodeForceAttach(document) {
         document.createElement = function (name) {                  \
             var el = elementConstructor.apply(document, arguments); \
                                                                     \
-            if (el instanceof HTMLMediaElement) { \
+            if (el instanceof HTMLMediaElement) {                   \
                 window.setTimeout(function() {                      \
                     if (!el.parentNode) {                           \
                         document.body.appendChild(el);              \


### PR DESCRIPTION
The code will now check if elements are media types, rather than checking if they are audio or video elements. This means if any other tags were created for media types for whatever reason, they will only have to be manually added in the "getMediaElementsFromDocument" function (which still has to be modified since there is no way to grab elements by interface) making maintenance easier. It is also more efficient since it only requires one check.

There is also a code style change to only use uppercase for tag names for better consistency, since element.tagName returns them as uppercase strings.

Everything seems fine with quick testing on PM 26.*