### PR TITLE
Discard script element when not needed.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -159,11 +159,13 @@ function updateStatesForDocument(states, document) {
         }
     }
 
-    let frameElements = document.getElementsByTagName("iframe");
-    for (let frameElement of frameElements) {
-        let frameWindow = frameElement.contentWindow;
-        if (frameWindow != frameWindow.top) {
-            updateStatesForDocument(states, frameWindow.document);
+    if (!hasAnyNonMutedMediaElements) {
+        let frameElements = document.getElementsByTagName("iframe");
+        for (let frameElement of frameElements) {
+            let frameWindow = frameElement.contentWindow;
+            if (frameWindow != frameWindow.top) {
+                updateStatesForDocument(states, frameWindow.document);
+            }
         }
     }
 }
@@ -301,6 +303,10 @@ function enableMediaNodeForceAttach(document) {
     scriptInject.type = "application/javascript";
     scriptInject.innerHTML = overwriteFunc;
     document.head.appendChild(scriptInject);
+
+    // Some websites don't like having another script tag on the DOM
+    // Removing the script element after it runs will satisfy the websites without stopping the code effect
+    document.head.removeChild(scriptInject);
 }
 
 function mutationEventListener(tab) {


### PR DESCRIPTION
This fixes #22 and it is possible that it is also the fix for #17 .

The script element doesn't have to hang around to do its job, it just needs to exist long enough to run its code. Websites should no longer have any problems with the script element. The attach point div will still have to remain and could cause problems; it would likely take something like Shadow DOM to fix that, but it is a feature of ES7 and so isn't an option.

Tested on latest version of PM 27. There doesn't seem to be any regressions on previously problematic websites and websites like soundcloud that require the script inject are working properly.

