### PR TITLE
Ignore events for non-media elements

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -253,13 +253,18 @@ function onKeyUp(event) {
 function onMediaElementEvent(event) {
     let mediaElement = event.target;
     let document = mediaElement.ownerDocument;
+
+    if ( !(mediaElement instanceof document.defaultView.HTMLMediaElement) ) {
+        return;
+    }
+
     let tab = findTabForDocument(document);
 
     if (tab.getAttribute(ENT_MUTED_ATTRIBUTE) === "true") {
         mediaElement.muted = true;
     }
-    if (event.type === "loadstart" && !tab.selected &&
-        Prefs.getValue("preventAutoBackgroundPlayback")) {
+    if (Prefs.getValue("preventAutoBackgroundPlayback") &&
+        event.type === "loadstart" && !tab.selected) {
         mediaElement.pause();
     } else {
         updateTabState(tab);


### PR DESCRIPTION
Some media events aren't restricted to media. For example, a loadstart even is fired on Youtube for HTMLImageElement objects in addition to HTMLMediaElement objects, which would cause a type error for the pause() function when using the auto background pause feature.

This changes the onMediaElementEvent function to return early if the event wasn't from a media element. This got rid of the errors that showed up in my youtube test case.